### PR TITLE
Update remoteCmd.js: uses sshCmdArgs from inputs

### DIFF
--- a/src/remoteCmd.js
+++ b/src/remoteCmd.js
@@ -1,6 +1,6 @@
 const { exec } = require('child_process');
 const crypto = require('crypto');
-const { sshServer, githubWorkspace, remotePort } = require('./inputs');
+const { sshServer, githubWorkspace, remotePort, sshCmdArgs } = require('./inputs');
 const { writeToFile, deleteFile } = require('./helpers');
 
 const handleError = (message, isRequired, callback) => {
@@ -21,7 +21,7 @@ const remoteCmd = async (content, privateKeyPath, isRequired, label) => new Prom
     const rsyncStdout = (process.env.RSYNC_STDOUT || '').substring(0, dataLimit);
     console.log(`Executing remote script: ssh -i ${privateKeyPath} ${sshServer}`);
     exec(
-      `DEBIAN_FRONTEND=noninteractive ssh -p ${(remotePort || 22)} -i ${privateKeyPath} -o StrictHostKeyChecking=no ${sshServer} 'RSYNC_STDOUT="${rsyncStdout}" bash -s' < ${filename}`,
+      `DEBIAN_FRONTEND=noninteractive ssh -p ${(remotePort || 22)} -i ${privateKeyPath} ${sshCmdArgs} ${sshServer} 'RSYNC_STDOUT="${rsyncStdout}" bash -s' < ${filename}`,
       (err, data = '', stderr = '') => {
         if (err) {
           const message = `⚠️ [CMD] Remote script failed: ${err.message}`;


### PR DESCRIPTION
uses sshCmdArgs from inputs instead of hardcoded argument `-o StrictHostKeyChecking=no`

see https://github.com/LogicsSoftwareGmbH/ctcockpit/issues/236#issuecomment-2517221789